### PR TITLE
ENH: support forkserver and spawn multiprocessing methods

### DIFF
--- a/src/aspire_bilby/plugin.py
+++ b/src/aspire_bilby/plugin.py
@@ -22,6 +22,8 @@ from .utils import (
     get_periodic_parameters,
     samples_from_bilby_result,
     samples_from_bilby_priors,
+    update_global_functions,
+    _initialize_fixed_parameters,
 )
 
 
@@ -440,3 +442,40 @@ class Aspire(Sampler):
                 if self._npool > 1:
                     kwargs["npool"] = self._npool
         super()._translate_kwargs(kwargs)
+
+    def _setup_pool(self):
+        # TODO: this should be updated once https://github.com/bilby-dev/bilby/pull/1009 is in a release
+
+        # In bilby<2.7 samplers don't have parameters and the global variable
+        # function doesn't need it.
+        parameters = self._search_parameter_keys
+        fixed_parameters = _initialize_fixed_parameters(self.priors)
+
+        if self.kwargs.get("pool", None) is not None:
+            logger.info("Using user defined pool.")
+            self.pool = self.kwargs["pool"]
+        elif self.npool is not None and self.npool > 1:
+            logger.info(f"Setting up multiproccesing pool with {self.npool} processes")
+            import multiprocessing
+
+            self.pool = multiprocessing.Pool(
+                processes=self.npool,
+                initializer=update_global_functions,
+                initargs=(
+                    self.likelihood,
+                    self.priors,
+                    fixed_parameters,
+                    parameters,
+                    self.use_ratio,
+                ),
+            )
+        else:
+            self.pool = None
+        update_global_functions(
+            bilby_likelihood=self.likelihood,
+            bilby_priors=self.priors,
+            fixed_parameters=fixed_parameters,
+            parameters=parameters,
+            use_ratio=self.use_ratio,
+        )
+        self.kwargs["pool"] = self.pool

--- a/src/aspire_bilby/utils.py
+++ b/src/aspire_bilby/utils.py
@@ -420,7 +420,9 @@ def get_inputs_from_bilby_pipe_ini(
         config_file, data_dump_file, suppress_bilby_logger=suppress_bilby_logger
     )
     parameters = bilby_priors.non_fixed_keys
-    funcs = get_aspire_functions(bilby_likelihood, bilby_priors, use_ratio=use_ratio)
+    funcs = get_aspire_functions(
+        bilby_likelihood, bilby_priors, parameters=parameters, use_ratio=use_ratio
+    )
     return Inputs(
         log_likelihood=funcs.log_likelihood,
         log_prior=funcs.log_prior,

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 from unittest.mock import patch
 
 import bilby
@@ -102,19 +103,21 @@ def test_run_sampler(
     )
 
 
+@pytest.mark.parametrize("start_method", ["fork", "spawn", "forkserver"])
 def test_run_sampler_pool(
     bilby_likelihood,
     bilby_priors,
     tmp_path,
     sampler_kwargs,
     flow_backend,
+    start_method,
 ):
-    from multiprocessing.dummy import Pool
-
     outdir = tmp_path / "test_run_sampler_pool"
     outdir.mkdir(parents=True, exist_ok=True)
 
-    with patch("multiprocessing.Pool", new=Pool):
+    ctx = mp.get_context(start_method)
+
+    with patch("multiprocessing.Pool", new=ctx.Pool):
         bilby.run_sampler(
             likelihood=bilby_likelihood,
             priors=bilby_priors,


### PR DESCRIPTION
As of Python 3.14, the default multiprocessing method will be `forkserver` rather than `fork`.

This PR prepares aspire-bilby for these changes by adding support for `forkserver` and `spawn`.